### PR TITLE
fix: escape plain text email bodies

### DIFF
--- a/src/mail-client.ts
+++ b/src/mail-client.ts
@@ -18,14 +18,33 @@ export class MailClient {
 
     private parseRecipients(recipientString?: string): any[] | null {
         if (!recipientString) return null;
-        return recipientString.split(",").map((email) => ({
-            name: "",
-            email: email.trim(),
-        }));
+        const recipients = recipientString
+            .split(",")
+            .map((email) => email.trim())
+            .filter(Boolean)
+            .map((email) => ({
+                name: "",
+                email,
+            }));
+
+        return recipients.length > 0 ? recipients : null;
+    }
+
+    private escapeHtml(text: string): string {
+        const replacements: Record<string, string> = {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            "\"": "&quot;",
+            "'": "&#39;",
+        };
+
+        return text.replace(/[&<>"']/g, (char) => replacements[char]);
     }
 
     private createHtmlBody(body: string): string {
-        return `<html><body><div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px;">${body.replace(/\n/g, "<br>")}</div></body></html>`;
+        const escapedBody = this.escapeHtml(body).replace(/\n/g, "<br>");
+        return `<html><body><div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px;">${escapedBody}</div></body></html>`;
     }
 
     private async apiRequest(path: string, options: RequestInit = {}): Promise<any> {

--- a/tests/mail-client.test.js
+++ b/tests/mail-client.test.js
@@ -279,6 +279,87 @@ describe("MailClient", () => {
         assert.deepStrictEqual(draftBody.bcc, [{ name: "", email: "bcc@test.com" }]);
     });
 
+    it("sendEmail ignores blank recipient entries", async () => {
+        const client = new MailClient("mock-token");
+
+        fetchMock.enqueue({
+            result: "success",
+            data: [
+                {
+                    uuid: "mb-uuid",
+                    hosting_id: 123,
+                    mailbox: "test",
+                    email: "test@test.com",
+                },
+            ],
+        });
+        await client.init();
+
+        fetchMock.enqueue({
+            result: "success",
+            data: { uuid: "draft-uuid", uid: "draft-uid" },
+        });
+        fetchMock.enqueue({
+            result: "success",
+            data: { etop: "2024-01-01T00:00:00+00:00" },
+        });
+
+        await client.sendEmail(
+            "a@test.com, , b@test.com,",
+            "Subject",
+            "Body",
+            ", cc@test.com,",
+        );
+
+        const calls = fetchMock.calls();
+        const draftBody = JSON.parse(calls[1].options.body);
+        assert.deepStrictEqual(draftBody.to, [
+            { name: "", email: "a@test.com" },
+            { name: "", email: "b@test.com" },
+        ]);
+        assert.deepStrictEqual(draftBody.cc, [{ name: "", email: "cc@test.com" }]);
+    });
+
+    it("createDraft escapes plain text body before wrapping it in HTML", async () => {
+        const client = new MailClient("mock-token");
+
+        fetchMock.enqueue({
+            result: "success",
+            data: [
+                {
+                    uuid: "mb-uuid",
+                    hosting_id: 123,
+                    mailbox: "test",
+                    email: "test@test.com",
+                },
+            ],
+        });
+        await client.init();
+
+        fetchMock.enqueue({
+            result: "success",
+            data: { uuid: "draft-uuid", uid: "draft-uid" },
+        });
+
+        await client.createDraft(
+            "to@test.com",
+            "Escaped body",
+            "<script>alert('x')</script>\nTom & Jerry \"quote\"",
+        );
+
+        const calls = fetchMock.calls();
+        const draftBody = JSON.parse(calls[1].options.body);
+        assert.ok(
+            draftBody.body.includes(
+                "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;<br>Tom &amp; Jerry &quot;quote&quot;",
+            ),
+        );
+        assert.ok(
+            !draftBody.body.includes("<script>"),
+            "plain text body should not be interpreted as HTML",
+        );
+    });
+
     it("uploadAttachment sets correct MIME type", async () => {
         const client = new MailClient("mock-token");
 


### PR DESCRIPTION
## Summary
- escape plain text email bodies before wrapping them in the HTML payload
- ignore blank entries in comma-separated recipient lists
- add regression coverage for both behaviors

## Why
The public tool inputs describe `body` as plain text, but the client previously inserted it directly into an HTML template. That meant HTML-like text could be interpreted as markup instead of being preserved as user text.

Blank recipient entries could also be sent when users provided trailing or repeated commas.

## Validation
- npm test