### PR TITLE
fix: derive server version from package metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,15 @@ import {McpServer} from "@modelcontextprotocol/sdk/server/mcp.js";
 import {z} from "zod";
 import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
 import {MailClient} from "./mail-client.js";
+import {createRequire} from "node:module";
+
+const require = createRequire(import.meta.url);
+const {version} = require("../package.json") as {version: string};
 
 const server = new McpServer(
     {
         name: "Infomaniak Mail MCP Server",
-        version: "1.1.2",
+        version,
     },
     {
         capabilities: {

--- a/tests/server-startup.test.js
+++ b/tests/server-startup.test.js
@@ -8,6 +8,9 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const entry = path.join(__dirname, "..", "dist", "index.js");
+const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+);
 
 // Launches dist/index.js the way `npx` / MCP clients do: through a bin symlink,
 // then drives a minimal MCP `initialize` handshake over stdio and resolves with
@@ -78,5 +81,6 @@ describe("server startup", () => {
             response.result.serverInfo,
             "initialize result should include serverInfo",
         );
+        assert.strictEqual(response.result.serverInfo.version, packageJson.version);
     });
 });


### PR DESCRIPTION
## Summary
- read the MCP server version from `package.json` instead of hardcoding it in the entry point
- add startup coverage to assert `serverInfo.version` matches package metadata

## Why
The package is currently published as `1.2.0`, while the MCP initialize response reports `1.1.2`. Reading the package version avoids this metadata drifting again on future releases.

## Validation
- npm test