### PR TITLE
feat: add search

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,23 @@ MCP Server for the Infomaniak Mail API.
 
 10. `mail_list_drafts`
     - List all drafts in the mailbox
-    - Returns: Draft threads with subject, date, and message UID
+     - Returns: Draft threads with subject, date, and message UID
+
+11. `mail_search_emails`
+    - Search emails by keyword, sender, recipient, subject, or date range
+    - Optional inputs:
+      - `query` (string): Full-text search in message body and metadata
+      - `from` (string): Filter by sender email or name
+      - `to` (string): Filter by recipient email or name
+      - `subject` (string): Filter by subject
+      - `since` (string): Start date (YYYY-MM-DD)
+      - `before` (string): End date (YYYY-MM-DD)
+      - `folder_id` (string): Limit search to a specific folder (searches all folders if omitted)
+      - `mailbox_uuid` (string): Mailbox UUID (uses primary if omitted)
+      - `limit` (number): Maximum results to return (default: 50)
+      - `offset` (number): Pagination offset (default: 0)
+    - Returns: List of matching emails with subject, from, to, date, preview, folder, and folder_id
+    - Note: At least one of query, from, to, subject, since, or before must be provided.
 
 ## Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,75 @@ server.tool(
 );
 
 server.tool(
+    "mail_search_emails",
+    "Search emails by keyword, sender, recipient, subject, or date range across all folders or within a specific folder",
+    {
+        query: z
+            .string()
+            .describe("Full-text search in message body and metadata")
+            .optional(),
+        from: z
+            .string()
+            .describe("Filter by sender email or name")
+            .optional(),
+        to: z
+            .string()
+            .describe("Filter by recipient email or name")
+            .optional(),
+        subject: z
+            .string()
+            .describe("Filter by subject")
+            .optional(),
+        since: z
+            .string()
+            .describe("Start date (YYYY-MM-DD)")
+            .optional(),
+        before: z
+            .string()
+            .describe("End date (YYYY-MM-DD)")
+            .optional(),
+        folder_id: z
+            .string()
+            .describe("Limit search to a specific folder. If omitted, searches all folders.")
+            .optional(),
+        mailbox_uuid: z
+            .string()
+            .describe("Mailbox UUID (optional, uses primary if omitted)")
+            .optional(),
+        limit: z
+            .number()
+            .describe("Maximum number of results to return")
+            .default(50),
+        offset: z
+            .number()
+            .describe("Offset for pagination")
+            .default(0),
+    },
+    async ({query, from, to, subject, since, before, folder_id, mailbox_uuid, limit, offset}) => {
+        const uuid = mailbox_uuid || await mailClient.getMailboxUuid();
+        const results = await mailClient.searchEmails(uuid, {
+            query,
+            from,
+            to,
+            subject,
+            since,
+            before,
+            folderId: folder_id,
+            limit,
+            offset,
+        });
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: JSON.stringify(results, null, 2),
+                },
+            ],
+        };
+    },
+);
+
+server.tool(
     "mail_read_email",
     "Read a specific email",
     {

--- a/src/mail-client.ts
+++ b/src/mail-client.ts
@@ -224,6 +224,85 @@ export class MailClient {
         }));
     }
 
+    async searchEmails(
+        mailboxUuid: string,
+        options: {
+            query?: string;
+            from?: string;
+            to?: string;
+            subject?: string;
+            since?: string;
+            before?: string;
+            folderId?: string;
+            limit?: number;
+            offset?: number;
+        },
+    ): Promise<any[]> {
+        const {
+            query,
+            from,
+            to,
+            subject,
+            since,
+            before,
+            folderId,
+            limit = 50,
+            offset = 0,
+        } = options;
+
+        if (!query && !from && !to && !subject && !since && !before) {
+            throw new Error(
+                "At least one search filter (query, from, to, subject, since, or before) must be provided.",
+            );
+        }
+
+        let searchFolderId = folderId;
+        let severywhere = "0";
+
+        if (!searchFolderId) {
+            severywhere = "1";
+            const folders = await this.listFolders(mailboxUuid);
+            const inbox = folders.find(
+                (f: any) => f.role === "INBOX" || f.role === "inbox",
+            );
+            if (!inbox) {
+                throw new Error("INBOX folder not found for search base.");
+            }
+            searchFolderId = inbox.id;
+        }
+
+        const params = new URLSearchParams();
+        params.set("offset", String(offset));
+        params.set("thread", "off");
+        params.set("severywhere", severywhere);
+        params.set("limit", String(limit));
+
+        if (query) params.set("scontains", query);
+        if (from) params.set("sfrom", from);
+        if (to) params.set("sto", to);
+        if (subject) params.set("ssubject", subject);
+        if (since) params.set("sfromdate", `${since} 00:00:00`);
+        if (before) params.set("stodate", `${before} 00:00:00`);
+
+        const response = await this.apiRequest(
+            `/mail/${mailboxUuid}/folder/${searchFolderId}/message?${params.toString()}`,
+        );
+
+        return (response.data?.threads || []).map((thread: any) => ({
+            thread_uid: thread.uid,
+            subject: thread.subject || "(no subject)",
+            from: thread.from?.map((f: any) => `${f.name} <${f.email}>`).join(", ") || "",
+            to: thread.to?.map((t: any) => `${t.name} <${t.email}>`).join(", ") || "",
+            date: thread.date,
+            messages_count: thread.messages_count,
+            unseen_messages: thread.unseen_messages,
+            preview: thread.messages?.[0]?.preview || "",
+            first_message_uid: thread.messages?.[0]?.uid?.split("@")[0] || null,
+            folder_id: thread.messages?.[0]?.folder_id || null,
+            folder: thread.messages?.[0]?.folder || null,
+        }));
+    }
+
     async readEmail(
         mailboxUuid: string,
         folderId: string,

--- a/tests/mail-client.test.js
+++ b/tests/mail-client.test.js
@@ -582,4 +582,173 @@ describe("MailClient", () => {
         assert.strictEqual(last.options.method, "DELETE");
         assert.ok(last.url.includes("draft-uuid"));
     });
+
+    it("searchEmails searches all folders with scontains when no folderId given", async () => {
+        const client = new MailClient("mock-token");
+
+        // init (needed for INBOX folder resolution)
+        fetchMock.enqueue({
+            result: "success",
+            data: [
+                {
+                    uuid: "mb-uuid",
+                    hosting_id: 123,
+                    mailbox: "test",
+                    email: "test@test.com",
+                },
+            ],
+        });
+        await client.init();
+
+        // folders response for INBOX resolution
+        fetchMock.enqueue({
+            result: "success",
+            data: [
+                { id: "inbox-id", name: "INBOX", role: "INBOX" },
+                { id: "sent-id", name: "Sent", role: "SENT" },
+            ],
+        });
+
+        // search response
+        fetchMock.enqueue({
+            result: "success",
+            data: {
+                threads: [
+                    {
+                        uid: "thread-1",
+                        subject: "Test result",
+                        from: [{ name: "Alice", email: "alice@test.com" }],
+                        to: [{ name: "Bob", email: "bob@test.com" }],
+                        date: "2026-06-21T21:36:56+0200",
+                        messages_count: 1,
+                        unseen_messages: 0,
+                        messages: [
+                            {
+                                uid: "10@eJwLTs0rAQADzwGb",
+                                preview: "Hello world",
+                                folder_id: "eJwLTs0rAQADzwGb",
+                                folder: "Sent",
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await client.searchEmails("mb-uuid", { query: "test" });
+
+        const calls = fetchMock.calls();
+        // call 0 = init, call 1 = listFolders, call 2 = search
+        const searchUrl = calls[2].url;
+        assert.ok(searchUrl.includes("scontains=test"), "URL must contain scontains=test");
+        assert.ok(searchUrl.includes("severywhere=1"), "URL must contain severywhere=1");
+        assert.ok(searchUrl.includes("thread=off"), "URL must contain thread=off");
+        assert.ok(searchUrl.includes("inbox-id"), "URL path must use INBOX folder id");
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].subject, "Test result");
+        assert.strictEqual(result[0].from, "Alice <alice@test.com>");
+        assert.strictEqual(result[0].to, "Bob <bob@test.com>");
+        assert.strictEqual(result[0].folder_id, "eJwLTs0rAQADzwGb");
+        assert.strictEqual(result[0].folder, "Sent");
+        assert.strictEqual(result[0].first_message_uid, "10");
+    });
+
+    it("searchEmails searches within a specific folder when folderId given", async () => {
+        const client = new MailClient("mock-token");
+
+        // search response (no init/folders needed since folderId is provided)
+        fetchMock.enqueue({
+            result: "success",
+            data: {
+                threads: [
+                    {
+                        uid: "thread-2",
+                        subject: "Folder search",
+                        from: [{ name: "Carol", email: "carol@test.com" }],
+                        to: [{ name: "Dave", email: "dave@test.com" }],
+                        date: "2026-07-01T10:00:00+0200",
+                        messages_count: 1,
+                        unseen_messages: 1,
+                        messages: [
+                            {
+                                uid: "5@customFolderId",
+                                preview: "Folder result",
+                                folder_id: "customFolderId",
+                                folder: "Custom",
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await client.searchEmails("mb-uuid", {
+            query: "folder",
+            folderId: "customFolderId",
+        });
+
+        const calls = fetchMock.calls();
+        const searchUrl = calls[0].url;
+        assert.ok(searchUrl.includes("customFolderId"), "URL path must use provided folder id");
+        assert.ok(searchUrl.includes("severywhere=0"), "URL must contain severywhere=0");
+        assert.ok(searchUrl.includes("scontains=folder"), "URL must contain scontains=folder");
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].folder, "Custom");
+    });
+
+    it("searchEmails combines multiple filters and formats dates correctly", async () => {
+        const client = new MailClient("mock-token");
+
+        fetchMock.enqueue({
+            result: "success",
+            data: {
+                threads: [
+                    {
+                        uid: "thread-3",
+                        subject: "Invoice June",
+                        from: [{ name: "Billing", email: "billing@test.com" }],
+                        to: [{ name: "Me", email: "me@test.com" }],
+                        date: "2026-06-15T08:00:00+0200",
+                        messages_count: 1,
+                        unseen_messages: 0,
+                        messages: [
+                            {
+                                uid: "20@folderEnc",
+                                preview: "Your invoice",
+                                folder_id: "folderEnc",
+                                folder: "Inbox",
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await client.searchEmails("mb-uuid", {
+            query: "invoice",
+            from: "billing@test.com",
+            subject: "Invoice",
+            since: "2026-06-01",
+            before: "2026-06-30",
+            folderId: "folderEnc",
+        });
+
+        const calls = fetchMock.calls();
+        const searchUrl = calls[0].url;
+        assert.ok(searchUrl.includes("scontains=invoice"), "must have scontains");
+        assert.ok(searchUrl.includes("sfrom=billing%40test.com"), "must have sfrom");
+        assert.ok(searchUrl.includes("ssubject=Invoice"), "must have ssubject");
+        assert.ok(searchUrl.includes("sfromdate=2026-06-01+00%3A00%3A00"), "must have formatted sfromdate");
+        assert.ok(searchUrl.includes("stodate=2026-06-30+00%3A00%3A00"), "must have formatted stodate");
+        assert.strictEqual(result.length, 1);
+    });
+
+    it("searchEmails throws when no search filters are provided", async () => {
+        const client = new MailClient("mock-token");
+
+        await assert.rejects(
+            client.searchEmails("mb-uuid", {}),
+            /At least one search filter/,
+        );
+    });
 });


### PR DESCRIPTION
## Context

The Mail MCP Server only supported listing emails by folder (`mail_list_emails`) with no way to search by keyword, sender, subject, or date range. Users had to page through entire folders to find specific messages.

🔗 **Issue:** https://github.com/Infomaniak/mcp-server-mail/issues/26

## Solution

Added a `mail_search_emails` tool that allows searching emails with the following criteria:

- **`query`** — full-text search in body and metadata
- **`from`** — filter by sender (email or name)
- **`to`** — filter by recipient (email or name)
- **`subject`** — filter by subject
- **`since` / `before`** — date range (`YYYY-MM-DD`)
- **`folder_id`** — limit to a specific folder (searches all folders if omitted)

### Technical details

- New `searchEmails()` method on `MailClient` (`src/mail-client.ts`) reusing the existing `/mail/{uuid}/folder/{folderId}/message` endpoint with search params (`scontains`, `sfrom`, `sto`, `ssubject`, `sfromdate`, `stodate`)
- When no `folder_id` is provided, the method auto-resolves the INBOX folder as base and uses `severywhere=1` for global search
- Response includes `folder_id` and `folder` fields for each message, enabling the caller to use `mail_read_email` with the correct folder
- 4 tests covering: all-folder search, folder-scoped search, multi-filter with date formatting, and no-filters error case
- README updated with tool #11

Closes #26