### PR TITLE
fix: return folder_id and folder from listEmails for multi-folder threads

### DIFF
--- a/src/mail-client.ts
+++ b/src/mail-client.ts
@@ -221,6 +221,8 @@ export class MailClient {
             unseen_messages: thread.unseen_messages,
             preview: thread.messages?.[0]?.preview || "",
             first_message_uid: thread.messages?.[0]?.uid?.split("@")[0] || null,
+            folder_id: thread.messages?.[0]?.folder_id || null,
+            folder: thread.messages?.[0]?.folder || null,
         }));
     }
 

--- a/tests/mail-client.test.js
+++ b/tests/mail-client.test.js
@@ -476,6 +476,39 @@ describe("MailClient", () => {
         assert.ok(!uid.includes("-"), "uid should be a simple sequence number");
     });
 
+    it("listEmails returns folder_id and folder so callers can read messages from multi-folder threads", async () => {
+        const client = new MailClient("mock-token");
+        fetchMock.enqueue({
+            result: "success",
+            data: {
+                threads: [
+                    {
+                        uid: "t-multi",
+                        subject: "Multi-folder thread",
+                        from: [{ name: "Alice", email: "alice@test.com" }],
+                        date: "2026-07-17T10:00:00+0200",
+                        messages_count: 2,
+                        unseen_messages: 0,
+                        messages: [
+                            {
+                                uid: "7@sentFolderId",
+                                preview: "Sent reply",
+                                folder_id: "sentFolderId",
+                                folder: "Sent",
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const result = await client.listEmails("mb", "inboxFolderId");
+
+        assert.strictEqual(result[0].first_message_uid, "7");
+        assert.strictEqual(result[0].folder_id, "sentFolderId");
+        assert.strictEqual(result[0].folder, "Sent");
+    });
+
     it("listDrafts finds folder with role DRAFT", async () => {
         const client = new MailClient("mock-token");
 


### PR DESCRIPTION
## Context

`mail_list_emails` returned a `first_message_uid` for each thread but omitted the `folder_id` of that message. For threads spanning multiple folders (e.g. INBOX + Sent), `thread.messages[0]` can live in a different folder than the one being queried, so callers passed the wrong `folder_id` to `mail_read_email` and got a `404 mail__message_not_found` error. `mail_search_emails` was unaffected because it already returns `folder_id` per message.

🔗 **Issue:** https://github.com/Infomaniak/mcp-server-mail/issues/33

## Solution

Add `folder_id` and `folder` fields to the `listEmails` response, mirroring the pattern already proven in `searchEmails`. Callers can now resolve the correct folder for each thread's first message and pass it to `mail_read_email`.

### Technical details

- `MailClient.listEmails()` (`src/mail-client.ts`) now returns `folder_id` and `folder` sourced from `thread.messages[0]`, identical to `searchEmails`
- Added a regression test reproducing the multi-folder scenario (INBOX listing where `messages[0]` lives in Sent) asserting the returned `folder_id`/`folder`
- Verified end-to-end against the live API: an INBOX thread whose first message lives in Sent now returns `folder_id` pointing to Sent, and `mail_read_email` succeeds with that folder

Fixes #33
